### PR TITLE
fix: remove ahm..rs api prefix

### DIFF
--- a/libs/portal-integration-angular/mocks/announcementMapper.ts
+++ b/libs/portal-integration-angular/mocks/announcementMapper.ts
@@ -2,14 +2,14 @@ import { rest } from 'msw'
 import { mockAnnouncements, mockAnnouncement } from './mockAnnouncement'
 
 export const mockedGetAnnouncements = rest.get(
-  '/ahm-api/announcement-help-management-rs/internal/announcements',
+  '/ahm-api/internal/announcements',
   (_, response, context) => {
     return response(context.json(mockAnnouncements))
   }
 )
 
 export const mockGetAnnouncement = rest.get(
-  '/ahm-api/announcement-help-management-rs/internal/announcements/*',
+  '/ahm-api/internal/announcements/*',
   (_, response, context) => {
     return response(context.json(mockAnnouncement))
   }

--- a/libs/portal-integration-angular/src/lib/services/announcements-api.service.ts
+++ b/libs/portal-integration-angular/src/lib/services/announcements-api.service.ts
@@ -18,13 +18,13 @@ export class AnnouncementsApiService {
     startDateTo: string,
     endDateFrom: string
   ): Observable<Array<AnnouncementItem>> {
-    return this.http.get<Array<AnnouncementItem>>(`./ahm-api/announcement-help-management-rs/internal/announcements`, {
+    return this.http.get<Array<AnnouncementItem>>(`./ahm-api/internal/announcements`, {
       params: { appId: appId, status: 'ACTIVE', startDateTo: startDateTo, endDateFrom: endDateFrom },
       headers: { Accept: 'application/json' },
     })
   }
 
   public getAnnouncementById(id: string): Observable<AnnouncementItem> {
-    return this.http.get<AnnouncementItem>(`./ahm-api/announcement-help-management-rs/internal/announcements/${id}`)
+    return this.http.get<AnnouncementItem>(`./ahm-api/internal/announcements/${id}`)
   }
 }

--- a/libs/portal-integration-angular/src/lib/services/help-api-service.ts
+++ b/libs/portal-integration-angular/src/lib/services/help-api-service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core'
 import { map, Observable } from 'rxjs'
 import { HelpData } from '../model/help-data'
 
-const baseUrl = './ahm-api/announcement-help-management-rs/internal/applications'
+const baseUrl = './ahm-api/internal/applications'
 
 @Injectable({ providedIn: 'root' })
 export class HelpPageAPIService {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onecx/onecx-portal-ui-libs",
-  "version": "3.6.0",
+  "version": "3.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onecx/onecx-portal-ui-libs",
-      "version": "3.6.0",
+      "version": "3.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular-architects/module-federation": "15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onecx/onecx-portal-ui-libs",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "license": "Apache-2.0",
   "scripts": {
     "sass": "npx sass libs/portal-integration-angular/assets/styles.scss libs/portal-integration-angular/assets/output.css"


### PR DESCRIPTION
This is required to be aligned to the removing of this api prefix in tkit-ahm backend