### PR TITLE
feat: overflow action buttons can be disabled in page-header

### DIFF
--- a/libs/portal-integration-angular/src/lib/core/components/page-header/page-header.component.ts
+++ b/libs/portal-integration-angular/src/lib/core/components/page-header/page-header.component.ts
@@ -185,6 +185,7 @@ export class PageHeaderComponent implements OnInit, OnChanges {
               title:
                 (a.titleKey ? translations[a.titleKey] : a.title) || (a.labelKey ? translations[a.labelKey] : a.label),
               command: a.actionCallback,
+              disabled: a.disabled,
             })),
           ]
         }


### PR DESCRIPTION
- Passed down the information from Action object to MenuItem about button enablement.
- Added tests to cover new functionality