### PR TITLE
fix: raise github actions version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,13 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18          
-      - uses: nrwl/nx-set-shas@v3
+          node-version: 20
+      - uses: nrwl/nx-set-shas@v4
       - name: Install deps
         run: npm ci
       - name: Lint


### PR DESCRIPTION
Fix the following error message when creating the release:
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.