### PR TITLE
fix: raise the ui libs version manually to 4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onecx/onecx-portal-ui-libs",
-  "version": "4.10.2",
+  "version": "4.12.0",
   "license": "Apache-2.0",
   "scripts": {
     "sass": "npx sass libs/portal-integration-angular/assets/styles.scss libs/portal-integration-angular/assets/output.css",


### PR DESCRIPTION
the tag was successfully created for 4.12.0
Only in the top-level package.json, the version was not raised. So it had to be raised manually.