### PR TITLE
fix: fix translations and auth in standalone

### DIFF
--- a/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
+++ b/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common'
 import { LOCALE_ID, NgModule } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
-import { MissingTranslationHandler, MissingTranslationHandlerParams, TranslateModule } from '@ngx-translate/core'
+import { TranslateModule } from '@ngx-translate/core'
 
 import { UserService } from '@onecx/angular-integration-interface'
 
@@ -27,13 +27,6 @@ import { SrcDirective } from './directives/src.directive'
 import { DynamicPipe } from './pipes/dynamic.pipe'
 import { OcxTimeAgoPipe } from './pipes/ocxtimeago.pipe'
 import { AppConfigService } from './services/app-config-service'
-
-export class AngularAcceleratorMissingTranslationHandler implements MissingTranslationHandler {
-  handle(params: MissingTranslationHandlerParams) {
-    console.log(`Missing translation for ${params.key}`, params)
-    return params.key
-  }
-}
 
 @NgModule({
   imports: [
@@ -95,7 +88,6 @@ export class AngularAcceleratorMissingTranslationHandler implements MissingTrans
     OcxTimeAgoPipe,
     SrcDirective,
     AdvancedDirective,
-    // DataListGridSortingComponent,
   ],
 })
 export class AngularAcceleratorModule {}

--- a/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
+++ b/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
@@ -1,16 +1,10 @@
 import { CommonModule } from '@angular/common'
-import { HttpClient } from '@angular/common/http'
 import { LOCALE_ID, NgModule } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
-import {
-  MissingTranslationHandler,
-  MissingTranslationHandlerParams,
-  TranslateLoader,
-  TranslateModule,
-} from '@ngx-translate/core'
+import { MissingTranslationHandler, MissingTranslationHandlerParams, TranslateModule } from '@ngx-translate/core'
 
-import { AppStateService, UserService } from '@onecx/angular-integration-interface'
+import { UserService } from '@onecx/angular-integration-interface'
 
 import { AngularAcceleratorPrimeNgModule } from './angular-accelerator-primeng.module'
 import { ColumnGroupSelectionComponent } from './components/column-group-selection/column-group-selection.component'
@@ -33,8 +27,6 @@ import { SrcDirective } from './directives/src.directive'
 import { DynamicPipe } from './pipes/dynamic.pipe'
 import { OcxTimeAgoPipe } from './pipes/ocxtimeago.pipe'
 import { AppConfigService } from './services/app-config-service'
-import { TranslationCacheService } from './services/translation-cache.service'
-import { createTranslateLoader } from './utils/create-translate-loader.utils'
 
 export class AngularAcceleratorMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {
@@ -47,18 +39,7 @@ export class AngularAcceleratorMissingTranslationHandler implements MissingTrans
   imports: [
     CommonModule,
     AngularAcceleratorPrimeNgModule,
-    TranslateModule.forRoot({
-      isolate: true,
-      loader: {
-        provide: TranslateLoader,
-        useFactory: createTranslateLoader,
-        deps: [HttpClient, AppStateService, TranslationCacheService],
-      },
-      missingTranslationHandler: {
-        provide: MissingTranslationHandler,
-        useClass: AngularAcceleratorMissingTranslationHandler,
-      },
-    }),
+    TranslateModule,
     FormsModule,
     RouterModule,
     ReactiveFormsModule,

--- a/libs/portal-integration-angular/src/lib/core/initializer/standalone.initializer.ts
+++ b/libs/portal-integration-angular/src/lib/core/initializer/standalone.initializer.ts
@@ -1,13 +1,12 @@
-import { firstValueFrom } from 'rxjs'
 import {
   AppStateService,
-  UserService,
-  ThemeService,
-  ConfigurationService,
   CONFIG_KEY,
-  IAuthService,
+  ConfigurationService,
+  ThemeService,
+  UserService,
 } from '@onecx/angular-integration-interface'
 import { MfeInfo } from '@onecx/integration-interface'
+import { firstValueFrom } from 'rxjs'
 import { PortalApiService } from '../../services/portal-api.service'
 import { UserProfileAPIService } from '../../services/userprofile-api.service'
 
@@ -20,7 +19,6 @@ const PORTAL_LOAD_INIT_ERR = 'PORTAL_LOAD_INIT_ERR'
  * This initializer only runs in standalone mode of the apps and not in portal-mf-shell
  */
 export function standaloneInitializer(
-  auth: IAuthService,
   config: ConfigurationService,
   portalApi: PortalApiService,
   themeService: ThemeService,

--- a/libs/portal-integration-angular/src/lib/core/portal-core.module.ts
+++ b/libs/portal-integration-angular/src/lib/core/portal-core.module.ts
@@ -1,4 +1,5 @@
 import { CommonModule, registerLocaleData } from '@angular/common'
+import de from '@angular/common/locales/de'
 import {
   APP_INITIALIZER,
   CUSTOM_ELEMENTS_SCHEMA,
@@ -9,70 +10,63 @@ import {
   Optional,
   SkipSelf,
 } from '@angular/core'
-import { HttpClient } from '@angular/common/http'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
-import de from '@angular/common/locales/de'
+import { MissingTranslationHandler, MissingTranslationHandlerParams, TranslateModule } from '@ngx-translate/core'
+import { AngularAcceleratorModule } from '@onecx/angular-accelerator'
 import {
-  MissingTranslationHandler,
-  MissingTranslationHandlerParams,
-  TranslateLoader,
-  TranslateModule,
-} from '@ngx-translate/core'
+  APPLICATION_NAME,
+  AUTH_SERVICE,
+  AppStateService,
+  ConfigurationService,
+  SANITY_CHECK,
+  ThemeService,
+  UserService,
+} from '@onecx/angular-integration-interface'
 import { MessageService } from 'primeng/api'
 import { ConfirmDialogModule } from 'primeng/confirmdialog'
-import { AutofocusDirective } from './directives/autofocus.directive'
+import { PortalApiService } from '../services/portal-api.service'
+import { UserProfileAPIService } from '../services/userprofile-api.service'
+import { AnnouncementBannerComponent } from './components/announcement-banner/announcement-banner.component'
+import { ButtonDialogComponent } from './components/button-dialog/button-dialog.component'
+import { DialogMessageContentComponent } from './components/button-dialog/dialog-message-content/dialog-message-content.component'
+import { OcxContentContainerComponent } from './components/content-container/content-container.component'
+import { OcxContentComponent } from './components/content/content.component'
+import { CreateOrEditSearchConfigDialogComponent } from './components/create-or-edit-search-config-dialog/create-or-edit-search-config-dialog.component'
+import { ColumnTogglerComponent } from './components/data-view-controls/column-toggler-component/column-toggler.component'
+import { DataViewControlsComponent } from './components/data-view-controls/data-view-controls.component'
+import { ViewTemplatePickerComponent } from './components/data-view-controls/view-template-picker/view-template-picker.component'
+import { DeleteDialogComponent } from './components/delete-dialog/delete-dialog.component'
+import { GlobalErrorComponent } from './components/error-component/global-error.component'
+import { HelpItemEditorComponent } from './components/help-item-editor/help-item-editor.component'
 import { AppInlineProfileComponent } from './components/inline-profile/inline-profile.component'
+import { LifecycleComponent } from './components/lifecycle/lifecycle.component'
+import { LoadingIndicatorComponent } from './components/loading-indicator/loading-indicator.component'
 import { LoadingComponent } from './components/loading/loading.component'
 import { MfeDebugComponent } from './components/mfe-debug/mfe-debug.component'
+import { NoHelpItemComponent } from './components/no-help-item/no-help-item.component'
 import { PageContentComponent } from './components/page-content/page-content.component'
 import { PagingInfoComponent } from './components/paging-info/paging-info.component'
 import { PortalFooterComponent } from './components/portal-footer/portal-footer.component'
 import { HeaderComponent } from './components/portal-header/header.component'
-import { PortalMenuComponent } from './components/portal-menu/portal-menu.component'
 import { PortalMenuHorizontalComponent } from './components/portal-menu-horizontal/portal-menu-horizontal.component'
+import { PortalMenuComponent } from './components/portal-menu/portal-menu.component'
 import { SubMenuComponent } from './components/portal-menu/submenu.component'
 import { PortalPageComponent } from './components/portal-page/portal-page.component'
-import { DeleteDialogComponent } from './components/delete-dialog/delete-dialog.component'
 import { PortalViewportComponent } from './components/portal-viewport/portal-viewport.component'
-import { UserAvatarComponent } from './components/user-avatar/user-avatar.component'
-import { DataViewControlsComponent } from './components/data-view-controls/data-view-controls.component'
-import { SearchCriteriaComponent } from './components/search-criteria/search-criteria.component'
-import { ColumnTogglerComponent } from './components/data-view-controls/column-toggler-component/column-toggler.component'
-import { standaloneInitializer } from './initializer/standalone.initializer'
-import { PortalApiService } from '../services/portal-api.service'
 import { CriteriaTemplateComponent } from './components/search-criteria/criteria-template/criteria-template.component'
-import { GlobalErrorComponent } from './components/error-component/global-error.component'
-import { AngularAcceleratorModule, TranslationCacheService, createTranslateLoader } from '@onecx/angular-accelerator'
-import {
-  UserService,
-  AppStateService,
-  ConfigurationService,
-  APPLICATION_NAME,
-  AUTH_SERVICE,
-  SANITY_CHECK,
-  ThemeService,
-} from '@onecx/angular-integration-interface'
-import { AnnouncementBannerComponent } from './components/announcement-banner/announcement-banner.component'
-import { ViewTemplatePickerComponent } from './components/data-view-controls/view-template-picker/view-template-picker.component'
+import { SearchCriteriaComponent } from './components/search-criteria/search-criteria.component'
 import { SupportTicketComponent } from './components/support-ticket/support-ticket.component'
-import { HelpItemEditorComponent } from './components/help-item-editor/help-item-editor.component'
-import { NoHelpItemComponent } from './components/no-help-item/no-help-item.component'
-import { PrimeNgModule } from './primeng.module'
+import { UserAvatarComponent } from './components/user-avatar/user-avatar.component'
+import { AutofocusDirective } from './directives/autofocus.directive'
 import { BasicDirective } from './directives/basic.directive'
+import { OcxContentContainerDirective } from './directives/content-container.directive'
+import { OcxContentDirective } from './directives/content.directive'
+import { LoadingIndicatorDirective } from './directives/loading-indicator.directive'
 import { PatchFormGroupValuesDirective } from './directives/patch-form-group-values.driective'
 import { SetInputValueDirective } from './directives/set-input-value.directive'
-import { LoadingIndicatorComponent } from './components/loading-indicator/loading-indicator.component'
-import { LoadingIndicatorDirective } from './directives/loading-indicator.directive'
-import { ButtonDialogComponent } from './components/button-dialog/button-dialog.component'
-import { DialogMessageContentComponent } from './components/button-dialog/dialog-message-content/dialog-message-content.component'
-import { OcxContentDirective } from './directives/content.directive'
-import { OcxContentComponent } from './components/content/content.component'
-import { OcxContentContainerComponent } from './components/content-container/content-container.component'
-import { OcxContentContainerDirective } from './directives/content-container.directive'
-import { UserProfileAPIService } from '../services/userprofile-api.service'
-import { CreateOrEditSearchConfigDialogComponent } from './components/create-or-edit-search-config-dialog/create-or-edit-search-config-dialog.component'
-import { LifecycleComponent } from './components/lifecycle/lifecycle.component'
+import { standaloneInitializer } from './initializer/standalone.initializer'
+import { PrimeNgModule } from './primeng.module'
 
 export class PortalMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {
@@ -89,15 +83,7 @@ export class PortalMissingTranslationHandler implements MissingTranslationHandle
     ReactiveFormsModule,
     PrimeNgModule,
     AngularAcceleratorModule,
-    TranslateModule.forRoot({
-      isolate: true,
-      loader: {
-        provide: TranslateLoader,
-        useFactory: createTranslateLoader,
-        deps: [HttpClient, AppStateService, TranslationCacheService],
-      },
-      missingTranslationHandler: { provide: MissingTranslationHandler, useClass: PortalMissingTranslationHandler },
-    }),
+    TranslateModule,
     ConfirmDialogModule,
   ],
   declarations: [

--- a/libs/portal-integration-angular/src/lib/core/portal-core.module.ts
+++ b/libs/portal-integration-angular/src/lib/core/portal-core.module.ts
@@ -16,7 +16,6 @@ import { MissingTranslationHandler, MissingTranslationHandlerParams, TranslateMo
 import { AngularAcceleratorModule } from '@onecx/angular-accelerator'
 import {
   APPLICATION_NAME,
-  AUTH_SERVICE,
   AppStateService,
   ConfigurationService,
   SANITY_CHECK,
@@ -208,7 +207,6 @@ export class PortalCoreModule {
           multi: true,
           useFactory: standaloneInitializer,
           deps: [
-            AUTH_SERVICE,
             ConfigurationService,
             PortalApiService,
             ThemeService,

--- a/libs/portal-integration-angular/src/lib/core/portal-core.module.ts
+++ b/libs/portal-integration-angular/src/lib/core/portal-core.module.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
-import { MissingTranslationHandler, MissingTranslationHandlerParams, TranslateModule } from '@ngx-translate/core'
+import { TranslateModule } from '@ngx-translate/core'
 import { AngularAcceleratorModule } from '@onecx/angular-accelerator'
 import {
   APPLICATION_NAME,
@@ -66,13 +66,6 @@ import { PatchFormGroupValuesDirective } from './directives/patch-form-group-val
 import { SetInputValueDirective } from './directives/set-input-value.directive'
 import { standaloneInitializer } from './initializer/standalone.initializer'
 import { PrimeNgModule } from './primeng.module'
-
-export class PortalMissingTranslationHandler implements MissingTranslationHandler {
-  handle(params: MissingTranslationHandlerParams) {
-    console.log(`Missing translation for ${params.key}`, params)
-    return params.key
-  }
-}
 
 @NgModule({
   imports: [


### PR DESCRIPTION
This PR removes the 'forRoot' initializing of the TranslateService in order to allow standalone use of PIA components.
Similar reasoning for the complete removel of the AuthService in the standalone initializer.