### PR TITLE
feat: fix styling issues for page header detail values + add ability to specify icon styles

### DIFF
--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
@@ -105,20 +105,21 @@
         >
         <span
           *ngIf="item.icon || item.value"
-          class="flex text-900 align-items-center gap-2 object-info-grid-value"
-          [ngClass]="generateItemStyle(item)"
+          class="object-info-grid-value"
           [title]="item.valueTooltip || item.tooltip || ''"
           name="object-detail-value"
         >
-          <i *ngIf="item.icon" class="{{item.icon}}" name="object-detail-icon"></i>
-          {{ item.value | dynamicPipe:item.valuePipe:item.valuePipeArgs}}
-          <p-button
-            *ngIf="item.actionItemIcon && item.actionItemCallback"
-            [icon]="item.actionItemIcon"
-            styleClass="p-button-text p-0 w-full"
-            [title]="item.actionItemTooltip || ''"
-            (onClick)="item.actionItemCallback()"
-          ></p-button>
+          <span class="flex text-900 align-items-center gap-2 w-max" [ngClass]="generateItemStyle(item)">
+            <i *ngIf="item.icon" class="{{item.icon}}" name="object-detail-icon"></i>
+            {{ item.value | dynamicPipe:item.valuePipe:item.valuePipeArgs}}
+            <p-button
+              *ngIf="item.actionItemIcon && item.actionItemCallback"
+              [icon]="item.actionItemIcon"
+              styleClass="p-button-text p-0 w-full"
+              [title]="item.actionItemTooltip || ''"
+              (onClick)="item.actionItemCallback()"
+            ></p-button>
+          </span>
         </span>
       </div>
     </ng-container>

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
@@ -107,9 +107,12 @@
           *ngIf="item.icon || item.value"
           class="object-info-grid-value"
           [title]="item.valueTooltip || item.tooltip || ''"
-          name="object-detail-value"
         >
-          <span class="flex text-900 align-items-center gap-2 w-max" [ngClass]="generateItemStyle(item)">
+          <span
+            class="flex text-900 align-items-center gap-2 w-max"
+            [ngClass]="generateItemStyle(item)"
+            name="object-detail-value"
+          >
             <i *ngIf="item.icon" class="{{item.icon}}" name="object-detail-icon"></i>
             {{ item.value | dynamicPipe:item.valuePipe:item.valuePipeArgs}}
             <p-button

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
@@ -113,7 +113,7 @@
             [ngClass]="generateItemStyle(item)"
             name="object-detail-value"
           >
-            <i *ngIf="item.icon" class="{{item.icon}}" name="object-detail-icon"></i>
+            <i *ngIf="item.icon" class='{{item.icon + " " + (item.iconStyleClass || "")}}' name="object-detail-icon"></i>
             {{ item.value | dynamicPipe:item.valuePipe:item.valuePipeArgs}}
             <p-button
               *ngIf="item.actionItemIcon && item.actionItemCallback"

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.stories.ts
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.stories.ts
@@ -349,6 +349,26 @@ export const WithObjectDetailsAndIcons = {
   },
 }
 
+export const WithObjectDetailsAndStyledIcons = {
+  render: Template,
+
+  args: {
+    header: 'My title',
+    subheader: 'My subtitle',
+    loading: false,
+    objectDetails: [
+      ...demoFields,
+      {
+        label: 'Styled Icon',
+        value: 'Confirmed',
+        icon: PrimeIcons.CHECK_CIRCLE,
+        iconStyleClass: 'text-red-400 fadein animation-duration-1000 animation-iteration-infinite'
+      }
+    ],
+    showBreadcrumbs: false,
+  },
+}
+
 export const DefaultLayout = {
   render: Template,
 

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.ts
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.ts
@@ -53,6 +53,7 @@ export interface ObjectDetailItem {
   labelTooltip?: string
   valueTooltip?: string
   icon?: PrimeIcon
+  iconStyleClass?: string
   labelPipe?: Type<any>
   valuePipe?: Type<any>
   valuePipeArgs?: string


### PR DESCRIPTION
Fixes layout issue detected by Bhupendra, which caused the objectDetailValue and the applied css classes to stretch to the full width of the flex column.

**Before**
![image](https://github.com/onecx/onecx-portal-ui-libs/assets/55296998/520f294f-77d1-43d5-81c7-018dec3195b8)

**After**
![image (1)](https://github.com/onecx/onecx-portal-ui-libs/assets/55296998/a8ce84db-dadc-4490-85f8-257b1eb8c2f1)
