### PR TITLE
fix: fixed removal of column leading to no refresh

### DIFF
--- a/libs/angular-accelerator/src/lib/components/custom-group-column-selector/custom-group-column-selector.component.ts
+++ b/libs/angular-accelerator/src/lib/components/custom-group-column-selector/custom-group-column-selector.component.ts
@@ -72,7 +72,8 @@ export class CustomGroupColumnSelectorComponent {
     const colIdsBefore = this.displayedColumns.map((column) => column.id)
     const colIdsAfter = this.displayedColumnsModel.map((column) => column.id)
 
-    if (!colIdsAfter.every((colId, i) => colId === colIdsBefore[i])) {
+    if ((!colIdsAfter.every((colId, i) => colId === colIdsBefore[i])) ||
+            colIdsAfter.length != colIdsBefore.length) {
       this.columnSelectionChanged.emit({ activeColumns: [...this.displayedColumnsModel] })
     }
 


### PR DESCRIPTION
When removing the last entry of the active columns the event was not emitted because the index positions of the active list did not change (no iteration over the removed element is happening). By checking the length as well, we cover this case.