### PR TITLE
fix: render template if no permission is undefined

### DIFF
--- a/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
+++ b/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
@@ -27,7 +27,6 @@ import { SrcDirective } from './directives/src.directive'
 import { DynamicPipe } from './pipes/dynamic.pipe'
 import { OcxTimeAgoPipe } from './pipes/ocxtimeago.pipe'
 import { AppConfigService } from './services/app-config-service'
-import { HasPermissionChecker } from './directives/if-permission.directive'
 
 export class AngularAcceleratorMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {

--- a/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
+++ b/libs/angular-accelerator/src/lib/angular-accelerator.module.ts
@@ -22,11 +22,12 @@ import { SearchConfigComponent } from './components/search-config/search-config.
 import { SearchHeaderComponent } from './components/search-header/search-header.component'
 import { AdvancedDirective } from './directives/advanced.directive'
 import { IfBreakpointDirective } from './directives/if-breakpoint.directive'
-import { IfPermissionDirective } from './directives/if-permission.directive'
+import { HAS_PERMISSION_CHECKER, IfPermissionDirective } from './directives/if-permission.directive'
 import { SrcDirective } from './directives/src.directive'
 import { DynamicPipe } from './pipes/dynamic.pipe'
 import { OcxTimeAgoPipe } from './pipes/ocxtimeago.pipe'
 import { AppConfigService } from './services/app-config-service'
+import { HasPermissionChecker } from './directives/if-permission.directive'
 
 export class AngularAcceleratorMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {
@@ -73,6 +74,10 @@ export class AngularAcceleratorMissingTranslationHandler implements MissingTrans
         return UserService.lang$.getValue()
       },
       deps: [UserService],
+    },
+    {
+      provide: HAS_PERMISSION_CHECKER,
+      useExisting: UserService,
     },
     AppConfigService,
   ],

--- a/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
@@ -68,6 +68,6 @@ export class IfPermissionDirective implements OnInit {
       }
       return result
     }
-    return this.permissionChecker && this.permissionChecker.hasPermission(permission)
+    return this.permissionChecker.hasPermission(permission)
   }
 }

--- a/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
@@ -40,10 +40,6 @@ export class IfPermissionDirective implements OnInit {
           this.viewContainer.createEmbeddedView(this.templateRef)
         }
       }
-    } else {
-      if (this.templateRef) {
-        this.viewContainer.createEmbeddedView(this.templateRef)
-      }
     }
   }
 

--- a/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
@@ -15,6 +15,15 @@ export interface HasPermissionChecker {
   hasPermission(permissionKey: string): boolean
 }
 
+/**
+ * This checker always returns true, basically disabling the permission system on the UI side
+ */
+export class AlwaysGrantPermissionChecker implements HasPermissionChecker {
+  hasPermission(_permissionKey: string): boolean {
+    return true;
+  }
+}
+
 export const HAS_PERMISSION_CHECKER = new InjectionToken<HasPermissionChecker>('hasPermission')
 
 @Directive({ selector: '[ocxIfPermission], [ocxIfNotPermission]' })

--- a/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
@@ -40,6 +40,10 @@ export class IfPermissionDirective implements OnInit {
           this.viewContainer.createEmbeddedView(this.templateRef)
         }
       }
+    } else {
+      if (this.templateRef) {
+        this.viewContainer.createEmbeddedView(this.templateRef)
+      }
     }
   }
 

--- a/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/if-permission.directive.ts
@@ -1,5 +1,21 @@
-import { Directive, ElementRef, Input, OnInit, Optional, Renderer2, TemplateRef, ViewContainerRef } from '@angular/core'
-import { UserService } from '@onecx/angular-integration-interface'
+import {
+  Directive,
+  ElementRef,
+  Inject,
+  InjectionToken,
+  Input,
+  OnInit,
+  Optional,
+  Renderer2,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core'
+
+export interface HasPermissionChecker {
+  hasPermission(permissionKey: string): boolean
+}
+
+export const HAS_PERMISSION_CHECKER = new InjectionToken<HasPermissionChecker>('hasPermission')
 
 @Directive({ selector: '[ocxIfPermission], [ocxIfNotPermission]' })
 export class IfPermissionDirective implements OnInit {
@@ -23,7 +39,8 @@ export class IfPermissionDirective implements OnInit {
     private renderer: Renderer2,
     private el: ElementRef,
     private viewContainer: ViewContainerRef,
-    private userService: UserService,
+    @Inject(HAS_PERMISSION_CHECKER)
+    private permissionChecker: HasPermissionChecker,
     @Optional() private templateRef?: TemplateRef<any>
   ) {}
 
@@ -51,6 +68,6 @@ export class IfPermissionDirective implements OnInit {
       }
       return result
     }
-    return this.userService.hasPermission(permission)
+    return this.permissionChecker && this.permissionChecker.hasPermission(permission)
   }
 }


### PR DESCRIPTION
If a permission provided is set to undefined, the ifPermission Directive would still not show the component. This leads to issues if you do not want to provide any permission for a component (standalone mode for example).


Better alternative: allow overwrite for hasPermission()