### PR TITLE
fix: fixed route matcher for webcomponents to ensure that routing is working for routes with empty prefix

### DIFF
--- a/libs/angular-webcomponents/src/lib/utils/webcomponent-router.utils.ts
+++ b/libs/angular-webcomponents/src/lib/utils/webcomponent-router.utils.ts
@@ -1,25 +1,33 @@
 import { Route, UrlMatcher, UrlSegment, UrlSegmentGroup } from '@angular/router'
 
 export function startsWith(prefix: string): UrlMatcher {
-  return (url: UrlSegment[], UrlSegmentGroup: UrlSegmentGroup, route: Route) => {
-    const urlWithoutBaseHref = sliceBaseHref(route, url)
+  return (url: UrlSegment[], _urlSegmentGroup: UrlSegmentGroup, route: Route) => {
+    const baseHref = getBaseHrefOfRoute(route)
+    if (`/${url.map((s) => s.path).join('/')}/`.startsWith(baseHref)) {
+      const urlWithoutBaseHref = sliceBaseHref(route, url)
 
-    const fullUrl = urlWithoutBaseHref.map((u) => u.path).join('/')
-    if (fullUrl.startsWith(prefix)) {
-      const prefixLength = prefix.split('/').filter((value) => value).length
-      return { consumed: url.slice(0, baseHrefSegmentAmount(url, urlWithoutBaseHref) + prefixLength) }
+      const fullUrl = urlWithoutBaseHref.map((u) => u.path).join('/')
+      if (fullUrl.startsWith(prefix)) {
+        const prefixLength = prefix.split('/').filter((value) => value).length
+        return { consumed: url.slice(0, baseHrefSegmentAmount(url, urlWithoutBaseHref) + prefixLength) }
+      }
     }
     return null
   }
 }
 
-export function sliceBaseHref(route: Route, url: UrlSegment[]): UrlSegment[] {
+export function getBaseHrefOfRoute(route: Route): string {
   const mfeBaseHref: string = route?.data?.['mfeInfo']?.baseHref
   if (!mfeBaseHref) {
     console.warn(
       'mfeInfo was not provided for route. initializeRouter function is required to be registered as app initializer.'
     )
   }
+  return mfeBaseHref
+}
+
+export function sliceBaseHref(route: Route, url: UrlSegment[]): UrlSegment[] {
+  const mfeBaseHref = getBaseHrefOfRoute(route)
 
   const baseHrefSegmentAmount = mfeBaseHref.split('/').filter((value) => value).length
   return url.slice(baseHrefSegmentAmount)


### PR DESCRIPTION
fixed route matcher for webcomponents to ensure that routing is working for routes with empty prefix