### PR TITLE
feat: use slots: shell-footer and shell-header-left

### DIFF
--- a/libs/angular-accelerator/assets/i18n/de.json
+++ b/libs/angular-accelerator/assets/i18n/de.json
@@ -150,6 +150,7 @@
     "EXPORT": "Alle Ereignisse exportieren"
   },
   "OCX_PAGE_HEADER": {
+    "IMAGE": "Seitentitelbild",
     "MORE_ACTIONS": "Weitere Aktionen",
     "HOME_DEFAULT_ARIA_LABEL": "Zur Startseite navigieren",
     "HOME_ARIA_LABEL": "Zu {{page}} navigieren"

--- a/libs/angular-accelerator/assets/i18n/en.json
+++ b/libs/angular-accelerator/assets/i18n/en.json
@@ -150,6 +150,7 @@
     "EXPORT": "Export all events"
   },
   "OCX_PAGE_HEADER": {
+    "IMAGE": "Page title image",
     "MORE_ACTIONS": "More actions",
     "HOME_DEFAULT_ARIA_LABEL": "Go to home page",
     "HOME_ARIA_LABEL": "Go to {{page}} home page"

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
@@ -6,6 +6,8 @@
       [home]="(home$ | async)?.menuItem ?? {}"
       [homeAriaLabel]="(home$ | async)?.page ? ('OCX_PAGE_HEADER.HOME_ARIA_LABEL' | translate: { page: (home$ | async)?.page}) : ('OCX_PAGE_HEADER.HOME_DEFAULT_ARIA_LABEL' | translate)"
       [attr.manual]="manualBreadcrumbs"
+    >
+      <ng-template pTemplate="separator"> <span class="pi pi-chevron-right" aria-hidden="true"></span> </ng-template
     ></p-breadcrumb>
   </ng-container>
 

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
@@ -19,7 +19,7 @@
           <img
             *ngIf="figureImage && !figureImageLoadError"
             [ocxSrc]="figureImage"
-            [alt]="'OCX_PAGE_HEADER.MORE_ACTIONS' | translate"
+            [alt]="'OCX_PAGE_HEADER.IMAGE' | translate"
             class="w-full border-round-sm"
             (error)="handleImageError()"
           />

--- a/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
+++ b/libs/angular-accelerator/src/lib/components/page-header/page-header.component.html
@@ -17,7 +17,7 @@
           <img
             *ngIf="figureImage && !figureImageLoadError"
             [ocxSrc]="figureImage"
-            alt="Figure Image"
+            [alt]="'OCX_PAGE_HEADER.MORE_ACTIONS' | translate"
             class="w-full border-round-sm"
             (error)="handleImageError()"
           />
@@ -81,13 +81,13 @@
               type="button"
               pButton
               icon="pi pi-ellipsis-v"
-              pTooltip="{{ 'OCX_PAGE_HEADER.MORE_ACTIONS' | translate }}"
-              tooltipEvent="hover"
-              tooltipPosition="top"
               class="more-actions-menu-button action-button ml-2"
               (click)="menu.toggle($event)"
               name="ocx-page-header-overflow-action-button"
-              [attr.aria-label]="('OCX_PAGE_HEADER.MORE_ACTIONS' | translate)"
+              [attr.aria-label]="'OCX_PAGE_HEADER.MORE_ACTIONS' | translate"
+              [pTooltip]="'OCX_PAGE_HEADER.MORE_ACTIONS' | translate"
+              tooltipEvent="hover"
+              tooltipPosition="top"
             ></button>
             <p-menu #menu [popup]="true" [model]="overflowActions" appendTo="body"></p-menu>
           </div>

--- a/libs/portal-integration-angular/assets/i18n/de.json
+++ b/libs/portal-integration-angular/assets/i18n/de.json
@@ -1,5 +1,6 @@
 {
   "OCX_HEADER": {
+    "USER_SETTINGS": "Profil und Einstellungen",
     "MENU_TOGGLE": "Menü ein/aus"
   },
   "OCX_PORTAL_VIEWPORT": {

--- a/libs/portal-integration-angular/assets/i18n/en.json
+++ b/libs/portal-integration-angular/assets/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "OCX_HEADER": {
+    "USER_SETTINGS": "Profile & Settings",
     "MENU_TOGGLE": "Menu on/off"
   },
   "OCX_PORTAL_VIEWPORT": {

--- a/libs/portal-integration-angular/src/lib/core/components/portal-header/header.component.html
+++ b/libs/portal-integration-angular/src/lib/core/components/portal-header/header.component.html
@@ -66,6 +66,7 @@
                 [title]="item.label"
                 [pTooltip]="item.label || ''"
                 tooltipPosition="bottom"
+                tooltipEvent="hover"
               >
                 <i [ngClass]="item.icon || ''" class="fs-large"></i>
               </a>
@@ -138,9 +139,10 @@
             class="layout-topbar-action flex flex-row justify-content-center align-items-center px-2 rounded-circle"
             pRipple
             (click)="onTopbarItemClick($event, 'profile')"
-            title="Profile"
-            pTooltip="Profile"
+            [attr.aria-label]="'OCX_HEADER.USER_SETTINGS' | translate"
+            [pTooltip]="'OCX_HEADER.USER_SETTINGS' | translate"
             tooltipPosition="bottom"
+            tooltipEvent="hover"
           >
             <ocx-user-avatar [user$]="currentUser$"></ocx-user-avatar>
           </a>

--- a/libs/shell-core/src/lib/components/portal-header/header.component.html
+++ b/libs/shell-core/src/lib/components/portal-header/header.component.html
@@ -1,25 +1,22 @@
 <div class="layout-topbar_flex" id="ocx_header" role="banner">
   <div
-    class="layout-topbar-left flex relative justify-content-center align-items-center"
+    class="layout-topbar-left relative flex justify-content-center align-items-center"
     [ngClass]="{'vertical-menu': !isHorizontalMenu}"
   >
-    <!-- LOGO -->
-    <ng-container *ngIf="currentTheme$ | async as theme">
-      <ocx-slot
-        *ngIf="isComponentDefined$ | async"
-        [name]="slotName"
-        [inputs]="{
-          dataType: 'logo',
-          themeName: theme.name,
-          imageUrl: theme.logoUrl,
-          imageStyleClass: 'max-h-3rem max-w-8rem',
-          logEnabled: false,
-          logPrefix: 'header left logo'
-        }"
-        [outputs]="{ imageLoadingFailed: logoLoadingEmitter }"
-      ></ocx-slot>
-      <div *ngIf="themeLogoLoadingFailed"><!-- portal logo --></div>
-    </ng-container>
+    <ocx-slot
+      name="onecx-shell-header-left"
+      class="flex flex-row flex-wrap align-items-center column-gap-3 row-gap-1"
+      [inputs]="{ imageStyleClass: 'h-3rem vertical-align-middle' }"
+      [outputs]="{ imageLoadingFailed: logoLoadingEmitter }"
+    >
+      <ng-template #skeleton>
+        <div class="flex align-items-center h-full justify-content-center" style="width: 26px">
+          <p-skeleton shape="circle" size="2rem" class="h-full flex align-items-center"></p-skeleton>
+        </div>
+      </ng-template>
+    </ocx-slot>
+    <div *ngIf="themeLogoLoadingFailed"><!-- portal logo --></div>
+
     <a
       id="ocx_vertical_menu_action_toggle"
       class="layout-menu-button"

--- a/libs/shell-core/src/lib/components/portal-header/header.component.html
+++ b/libs/shell-core/src/lib/components/portal-header/header.component.html
@@ -25,15 +25,17 @@
       class="layout-menu-button"
       (click)="onMenuButtonClick($event)"
       pRipple
+      [attr.aria-label]="'OCX_HEADER.MENU_TOGGLE' | translate"
       [pTooltip]="'OCX_HEADER.MENU_TOGGLE' | translate"
       tooltipPosition="top"
       tooltipEvent="hover"
     >
-      <i
+      <span
         id="ocx_vertical_menu_action_toggle_icon"
         class="pi"
         [ngClass]="'pi-chevron-' + (isStaticMenuVisible ? 'left' : 'right')"
-      ></i>
+        aria-hidden="true"
+      ></span>
     </a>
   </div>
 

--- a/libs/shell-core/src/lib/components/portal-header/header.component.ts
+++ b/libs/shell-core/src/lib/components/portal-header/header.component.ts
@@ -1,10 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { animate, style, transition, trigger } from '@angular/animations'
 import { UntilDestroy } from '@ngneat/until-destroy'
-import { Observable } from 'rxjs'
-
-import { SlotService } from '@onecx/angular-remote-components'
-import { Theme, ThemeService } from '@onecx/angular-integration-interface'
 
 @Component({
   selector: 'ocx-shell-header',
@@ -30,19 +26,10 @@ export class HeaderComponent {
   @Input() isStaticMenuVisible = false
   @Output() menuButtonClick: EventEmitter<any> = new EventEmitter()
 
-  // slot configuration: get theme logo
-  public slotName = 'onecx-theme-data'
-  public isComponentDefined$: Observable<boolean> // check a component was assigned
-  public currentTheme$: Observable<Theme>
   public logoLoadingEmitter = new EventEmitter<boolean>()
   public themeLogoLoadingFailed = false
 
-  constructor(
-    private readonly themeService: ThemeService,
-    private readonly slotService: SlotService
-  ) {
-    this.isComponentDefined$ = this.slotService.isSomeComponentDefinedForSlot(this.slotName)
-    this.currentTheme$ = this.themeService.currentTheme$.asObservable()
+  constructor() {
     this.logoLoadingEmitter.subscribe((data: boolean) => {
       this.themeLogoLoadingFailed = data
     })

--- a/libs/shell-core/src/lib/components/portal-viewport/portal-viewport.component.html
+++ b/libs/shell-core/src/lib/components/portal-viewport/portal-viewport.component.html
@@ -49,8 +49,19 @@
         </ng-container>
       </div>
 
-      <ocx-slot name="onecx-page-footer"></ocx-slot>
+      <ocx-slot
+        name="onecx-shell-footer"
+        class="onecx-shell-footer mx-3 py-2 flex flex-row flex-wrap align-items-center column-gap-3 row-gap-1 text-sm"
+        [inputs]="{ imageStyleClass: 'h-1rem vertical-align-middle' }"
+      >
+        <ng-template #skeleton>
+          <div class="flex align-items-center h-full justify-content-center" style="width: 26px">
+            <p-skeleton shape="circle" size="2rem" class="h-full flex align-items-center"></p-skeleton>
+          </div>
+        </ng-template>
+      </ocx-slot>
     </div>
+
     <div *ngIf="menuActive || !!activeTopbarItem" class="layout-mask modal-in"></div>
   </ng-container>
 

--- a/libs/shell-core/src/lib/components/portal-viewport/portal-viewport.component.scss
+++ b/libs/shell-core/src/lib/components/portal-viewport/portal-viewport.component.scss
@@ -1,0 +1,8 @@
+:host ::ng-deep {
+  /* the 2nd child (the menu) should fill the rest of space */
+  .onecx-shell-footer {
+    div:nth-child(2) {
+      flex-grow: 1;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onecx/onecx-portal-ui-libs",
-  "version": "5.43.0",
+  "version": "5.45.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onecx/onecx-portal-ui-libs",
-      "version": "5.43.0",
+      "version": "5.45.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -129,7 +129,7 @@
     },
     "libs/portal-layout-styles": {
       "name": "@onecx/portal-layout-styles",
-      "version": "5.43.0",
+      "version": "5.45.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "tslib": "^2.6.3"


### PR DESCRIPTION
* use slot onecx-shell-footer instead onecx-page-footer (more flexibility to assign separated content)
* add new slot onecx-shell-header-left to have more flexibility for content (usually we assign the theme logo component)
* improve ay11 for breadcrumbs (exclude the separator from reading)