### PR TITLE
feat: v5 channel

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -8,7 +8,7 @@ module.exports = {
     {
       name: 'v5',
       range: '5.x.x',
-      channel: false,
+      channel: 'v5',
     },
     'main',
   ],


### PR DESCRIPTION
Change the channel for the v5 branch to make sure it is not overwriting the latest tag of the main branch releases