### PR TITLE
fix: temporarily remove deprecation warnings from PIA components to avoid usage conflicts

### DIFF
--- a/libs/portal-integration-angular/src/lib/core/components/data-view-controls/data-view-controls.component.ts
+++ b/libs/portal-integration-angular/src/lib/core/components/data-view-controls/data-view-controls.component.ts
@@ -118,6 +118,7 @@ export interface DataViewControlTranslations {
 }
 
 /**
+ * TODO: deprecate this before core apps are migrated to v6
  * deprecated Will be split up in separate compoments for better abstraction layers
  */
 @Component({
@@ -138,6 +139,7 @@ export class DataViewControlsComponent implements OnInit, OnChanges {
   @Input() columnDefinitions: { field: string; header: string; active?: boolean; translationPrefix?: string }[] = []
   @Input() columnTemplates: ColumnViewTemplate[] = []
   /**
+   * TODO: deprecate this before core apps are migrated to v6
    * deprecated Instead, please use the `translations` input and specify the `templatePickerDropdownPlaceholder` property.
    *
    * Will be overwritten by `translations.templatePickerDropdownPlaceholder` if it is specified.

--- a/libs/portal-integration-angular/src/lib/core/components/page-content/page-content.component.ts
+++ b/libs/portal-integration-angular/src/lib/core/components/page-content/page-content.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core'
 /**
+ * TODO: deprecate this before core apps are migrated to v6
  * deprecated This component will be removed in favor of ocx-content and ocx-content-container in a future release.
  */
 @Component({

--- a/libs/portal-integration-angular/src/lib/core/components/portal-page/portal-page.component.ts
+++ b/libs/portal-integration-angular/src/lib/core/components/portal-page/portal-page.component.ts
@@ -4,6 +4,7 @@ import { AppStateService } from '@onecx/angular-integration-interface'
 import { UserService } from '@onecx/angular-integration-interface'
 
 /**
+ * TODO: deprecate this before core apps are migrated to v6
  * deprecated
  * Please import from `@onecx/angular-utils` instead.
  */

--- a/libs/portal-integration-angular/src/lib/core/components/search-criteria/search-criteria.component.ts
+++ b/libs/portal-integration-angular/src/lib/core/components/search-criteria/search-criteria.component.ts
@@ -7,6 +7,7 @@ import { AppStateService } from '@onecx/angular-integration-interface'
 import { UserService } from '@onecx/angular-integration-interface'
 
 /**
+ * TODO: deprecate this before core apps are migrated to v6
  * deprecated Will be replaced by ocx-search-header
  */
 @Component({

--- a/libs/portal-integration-angular/src/lib/core/components/user-avatar/user-avatar.component.ts
+++ b/libs/portal-integration-angular/src/lib/core/components/user-avatar/user-avatar.component.ts
@@ -5,6 +5,7 @@ import { API_PREFIX } from '../../../api/constants'
 import { UserProfile } from '../../../model/user-profile.model'
 
 /**
+ * TODO: deprecate this before core apps are migrated to v6
  * deprecated Replace with onecx-avatar-image slot
  */
 @Component({


### PR DESCRIPTION
This PR temporarily removes all deprecation warnings matching the following search pattern:
<img width="571" height="100" alt="grafik" src="https://github.com/user-attachments/assets/eefe950d-b849-48b0-89e8-4bc01eb7374a" />
This is done to avoid conflicts and deprecation warnings when using deprecated components that have been moved to a different library but still have the same tag name.
