### PR TITLE
fix: set height of header left area and footer

### DIFF
--- a/libs/shell-core/src/lib/components/portal-header/header.component.scss
+++ b/libs/shell-core/src/lib/components/portal-header/header.component.scss
@@ -54,6 +54,7 @@ $menuWrapperWidth: 17rem;
 
   .layout-topbar-left {
     width: 11rem;
+    height: 100%;
 
     &.vertical-menu {
       flex: 0 0 $menuWrapperWidth;

--- a/libs/shell-core/src/lib/components/portal-viewport/portal-viewport.component.html
+++ b/libs/shell-core/src/lib/components/portal-viewport/portal-viewport.component.html
@@ -50,10 +50,10 @@
       </div>
 
       <!-- page footer -->
-      <footer>
+      <footer class="h-2rem">
         <ocx-slot
           name="onecx-shell-footer"
-          class="onecx-shell-footer mx-3 flex flex-row flex-wrap align-items-center column-gap-3 row-gap-1 text-sm"
+          class="onecx-shell-footer mx-3 h-full flex flex-row flex-wrap align-items-center column-gap-3 row-gap-1 text-sm"
           [inputs]="{ imageStyleClass: 'h-1rem vertical-align-middle' }"
         >
           <ng-template #skeleton>


### PR DESCRIPTION
* adequately to the setting in header right, the height of header left must be the same: use the maximum of available space (=height: 100%) => the bg color used for this area have to be shown on the complete area
* same on footer: set a fix height for this area (maybe this is not complete optimal, depending on assigned components to the slot below the footer tag)