### PR TITLE
feat: help-ui angular 19 migration - tooltip changes in data-table component

### DIFF
--- a/libs/angular-accelerator/src/lib/components/data-table/data-table.component.html
+++ b/libs/angular-accelerator/src/lib/components/data-table/data-table.component.html
@@ -22,6 +22,8 @@
         icon="pi pi-eye"
         (click)="onViewRow(rowObject)"
         [attr.name]="'data-table-action-button'"
+        [ocxTooltip]="'OCX_DATA_TABLE.ACTIONS.VIEW' | translate"
+        tooltipPosition="top"
       ></button>
       } @if (editTableRowObserved && (!editActionVisibleField || fieldIsTruthy(rowObject, editActionVisibleField))) {
       <button
@@ -35,6 +37,8 @@
         icon="pi pi-pencil"
         (click)="onEditRow(rowObject)"
         [attr.name]="'data-table-action-button'"
+        [ocxTooltip]="'OCX_DATA_TABLE.ACTIONS.EDIT' | translate"
+        tooltipPosition="top"
       ></button>
       } @if (deleteTableRowObserved && (!deleteActionVisibleField || fieldIsTruthy(rowObject,
       deleteActionVisibleField))) {
@@ -49,6 +53,8 @@
         icon="pi pi-trash"
         (click)="onDeleteRow(rowObject)"
         [attr.name]="'data-table-action-button'"
+        [ocxTooltip]="'OCX_DATA_TABLE.ACTIONS.DELETE' | translate"
+        tooltipPosition="top"
       ></button>
       } @for (action of inlineActions$ | async; track action) { @if ((!action.actionVisibleField ||
       fieldIsTruthy(rowObject, action.actionVisibleField))) {
@@ -139,7 +145,14 @@
           class="table-header-wrapper flex flex-column justify-content-between align-items-start"
           style="height: 100%"
         >
-          <span class="flex" id="{{column.id}}-header-name">{{ column.nameKey | translate }}</span>
+          <span
+            class="flex"
+            id="{{column.id}}-header-name"
+            [ocxTooltip]="column.tooltipKey ? (column.tooltipKey | translate) : ''"
+            tooltipPosition="top"
+          >
+            {{ column.nameKey | translate }}
+          </span>
           <span class="flex icon-button-header-wrapper">
             @if (column.sortable) {
             <button
@@ -149,7 +162,7 @@
               [class.pi-sort-amount-down]="column?.id === sortColumn && sortDirection === 'DESCENDING'"
               (click)="onSortColumnClick(column.id)"
               [ocxTooltip]="sortIconTitle(column.id) | translate "
-              tooltipPosition="bottom"              
+              tooltipPosition="top"              
               [attr.aria-label]="('OCX_DATA_TABLE.TOGGLE_BUTTON.ARIA_LABEL' | translate: { column: (column.nameKey | translate), direction: (sortDirectionToTitle(columnNextSortDirection(column.id)) | translate)})"
             ></button>
             } @if (currentEqualFilterOptions$ | async; as equalFilterOptions) { @if (columnFilterTemplates$ | async; as
@@ -169,6 +182,8 @@
               filterBy="toFilterBy"
               (onFocus)="onFilterChosen(column)"
               [title]="'OCX_DATA_TABLE.FILTER_TITLE' | translate"
+              [ocxTooltip]="'OCX_DATA_TABLE.FILTER_TITLE' | translate"
+              tooltipPosition="top"
               [ariaLabel]="'OCX_DATA_TABLE.COLUMN_FILTER_ARIA_LABEL' | translate"
               [ariaFilterLabel]="('OCX_DATA_TABLE.FILTER_ARIA_LABEL' | translate: { column: column.nameKey | translate})"
             >
@@ -206,6 +221,8 @@
               appendTo="body"
               (onFocus)="onFilterChosen(column)"
               [title]="'OCX_DATA_TABLE.FILTER_TITLE' | translate"
+              [ocxTooltip]="'OCX_DATA_TABLE.FILTER_TITLE' | translate"
+              tooltipPosition="top"
               [ariaLabel]="'OCX_DATA_TABLE.COLUMN_FILTER_ARIA_LABEL' | translate"
               [ariaFilterLabel]="('OCX_DATA_TABLE.FILTER_ARIA_LABEL' | translate: { column: column.nameKey | translate})"
             >

--- a/libs/angular-accelerator/src/lib/model/data-table-column.model.ts
+++ b/libs/angular-accelerator/src/lib/model/data-table-column.model.ts
@@ -4,6 +4,7 @@ import { FilterType } from './filter.model'
 export interface DataTableColumn {
   columnType: ColumnType
   nameKey: string
+  tooltipKey?: string
   id: string
   sortable?: boolean
   filterable?: boolean


### PR DESCRIPTION
Updated data-table component and added optional tooltipKey field to DataTableColumn model to enable per-column header tooltips, while ensuring that all tooltips are positioned above the cursor.

The changes enable onecx-help-ui migration to Angular-19, by allowing ocx-interactive-data-view to use dynamic tooltips for columns and predefined tooltips for buttons.