### PR TITLE
refactor: made nx dependencies optional

### DIFF
--- a/libs/accelerator/package.json
+++ b/libs/accelerator/package.json
@@ -10,8 +10,15 @@
     "tslib": "^2.6.3",
     "rxjs": "^7.8.1",
     "@nx/devkit": "^20.3.0",
-    "@nx/module-federation": "20.4.0",
     "@onecx/nx-migration-utils": "^6.19.0"
+  },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/libs/accelerator/src/lib/utils/get-onecx-shared-recommendations.spec.ts
+++ b/libs/accelerator/src/lib/utils/get-onecx-shared-recommendations.spec.ts
@@ -1,0 +1,25 @@
+import type { SharedLibraryConfig as NxSharedLibraryConfig } from '@nx/module-federation'
+
+describe('getOneCXSharedRecommendations', () => {
+  it('accepts Nx SharedLibraryConfig objects and normalizes fields', async () => {
+    const { getOneCXSharedRecommendations } = await import('./get-onecx-shared-recommendations')
+
+    const sharedConfig: NxSharedLibraryConfig = {
+      singleton: true,
+      strictVersion: true,
+      eager: true,
+    } as unknown as NxSharedLibraryConfig
+
+    const result = getOneCXSharedRecommendations('@angular/core', sharedConfig as unknown as any)
+
+    expect(result).toBe(sharedConfig)
+    expect(sharedConfig.singleton).toBe(false)
+    expect(sharedConfig.strictVersion).toBe(false)
+    expect(sharedConfig.eager).toBe(false)
+  })
+
+  it('returns false for non-matching libraries', async () => {
+    const { getOneCXSharedRecommendations } = await import('./get-onecx-shared-recommendations')
+    expect(getOneCXSharedRecommendations('not-shared-lib', {})).toBe(false)
+  })
+})

--- a/libs/accelerator/src/lib/utils/get-onecx-shared-recommendations.ts
+++ b/libs/accelerator/src/lib/utils/get-onecx-shared-recommendations.ts
@@ -1,4 +1,11 @@
-import { SharedLibraryConfig } from '@nx/module-federation'
+export interface SharedLibraryConfig {
+  singleton?: boolean
+  strictVersion?: boolean
+  eager?: boolean
+  requiredVersion?: string | false
+  version?: string
+  includeSecondaries?: boolean
+}
 
 const sharedLibraryPatterns: RegExp[] = [/^@angular.*$/, /^@onecx.*$/, /^rxjs.*$/, /^primeng.*$/, /^@ngx-translate.*$/]
 
@@ -9,6 +16,7 @@ export function getOneCXSharedRecommendations(
   if (!sharedLibraryPatterns.some((pattern) => pattern.test(libraryName))) {
     return false
   }
+
   sharedConfig.singleton = false
   sharedConfig.strictVersion = false
   sharedConfig.eager = false

--- a/libs/angular-accelerator/package.json
+++ b/libs/angular-accelerator/package.json
@@ -32,6 +32,14 @@
     "@onecx/nx-migration-utils": "^6.19.0",
     "@primeng/themes": "^19.0.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "exports": {
     ".": {

--- a/libs/angular-auth/package.json
+++ b/libs/angular-auth/package.json
@@ -20,6 +20,12 @@
   "peerDependenciesMeta": {
     "keycloak-js": {
       "optional": true
+    },
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
     }
   },
   "publishConfig": {

--- a/libs/angular-integration-interface/package.json
+++ b/libs/angular-integration-interface/package.json
@@ -19,6 +19,14 @@
     "jest-extended": "^6.0.0",
     "typescript": "^5.5.4"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "publishConfig": {
     "access": "public"

--- a/libs/angular-remote-components/package.json
+++ b/libs/angular-remote-components/package.json
@@ -17,6 +17,14 @@
     "@nx/devkit": "^20.3.0",
     "@onecx/nx-migration-utils": "^6.19.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "publishConfig": {
     "access": "public"

--- a/libs/angular-standalone-shell/package.json
+++ b/libs/angular-standalone-shell/package.json
@@ -20,6 +20,14 @@
     "primeng": "^19.0.0",
     "@ngx-translate/core": "^16.0.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "publishConfig": {
     "access": "public"

--- a/libs/angular-testing/package.json
+++ b/libs/angular-testing/package.json
@@ -12,6 +12,14 @@
     "@nx/devkit": "^20.3.0",
     "@onecx/nx-migration-utils": "^6.19.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "publishConfig": {
     "access": "public"

--- a/libs/angular-utils/package.json
+++ b/libs/angular-utils/package.json
@@ -26,6 +26,14 @@
     "@phenomnomnominal/tsquery": "^6",
     "typescript": "^5.5.4"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/libs/angular-webcomponents/package.json
+++ b/libs/angular-webcomponents/package.json
@@ -20,6 +20,14 @@
     "@nx/devkit": "^20.3.0",
     "@onecx/nx-migration-utils": "^6.19.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "publishConfig": {
     "access": "public"

--- a/libs/integration-interface/package.json
+++ b/libs/integration-interface/package.json
@@ -15,6 +15,14 @@
     "@phenomnomnominal/tsquery": "^6",
     "typescript": "^5.5.4"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "type": "commonjs",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/libs/ngrx-accelerator/package.json
+++ b/libs/ngrx-accelerator/package.json
@@ -24,6 +24,14 @@
     "@nx/devkit": "^20.3.0",
     "@onecx/nx-migration-utils": "^6.19.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/libs/nx-migration-utils/package.json
+++ b/libs/nx-migration-utils/package.json
@@ -15,6 +15,11 @@
     "postcss": "^8.5.0",
     "postcss-scss": "^4.0.9"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    }
+  },
   "type": "commonjs",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/libs/shell-core/package.json
+++ b/libs/shell-core/package.json
@@ -22,6 +22,14 @@
     "@nx/devkit": "^20.3.0",
     "@onecx/nx-migration-utils": "^6.19.0"
   },
+  "peerDependenciesMeta": {
+    "@nx/devkit": {
+      "optional": true
+    },
+    "@onecx/nx-migration-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {},
   "type": "commonjs",
   "main": "./src/index.js",


### PR DESCRIPTION
Nx peer dependencies and usage caused type errors for pure angular core apps

- removed nx/module-federation import in getSharedDependencies
- added getSharedDependencies tests 
- made nx dependencies optional in package.json

- tested migrations
- tested angular core app build (announcement-ui)
- tested angular-19 preloader build