### PR TITLE
fix: added .card styling from v5

### DIFF
--- a/libs/angular-accelerator/assets/styles.scss
+++ b/libs/angular-accelerator/assets/styles.scss
@@ -3,3 +3,5 @@
 @import '/node_modules/primeflex/primeflex.scss';
 
 @import '../src/lib/directives/loading-indicator.directive.scss';
+
+@import '../src/lib/directives/content.directive.scss'; 

--- a/libs/angular-accelerator/src/lib/components/content/content.component.spec.ts
+++ b/libs/angular-accelerator/src/lib/components/content/content.component.spec.ts
@@ -44,13 +44,13 @@ describe('OcxContentComponent', () => {
     })
 
     it('should render a ocxContent card with no title by default', async () => {
-      const expectedClasses = ['card']
+      const expectedClasses = ['ocxCard']
       expect(await ocxContentHarness.getContentClasses()).toEqual(expectedClasses)
       expect(await ocxContentHarness.hasTitle(titleBaseId)).toEqual(false)
     })
 
     it('should render a ocxContent card with a title, when given a title via input', async () => {
-      const expectedClasses = ['card']
+      const expectedClasses = ['ocxCard']
       expect(await ocxContentHarness.getContentClasses()).toEqual(expectedClasses)
       expect(await ocxContentHarness.hasTitle(titleBaseId)).toEqual(false)
 

--- a/libs/angular-accelerator/src/lib/components/content/content.component.spec.ts
+++ b/libs/angular-accelerator/src/lib/components/content/content.component.spec.ts
@@ -44,13 +44,13 @@ describe('OcxContentComponent', () => {
     })
 
     it('should render a ocxContent card with no title by default', async () => {
-      const expectedClasses = ['ocxCard']
+      const expectedClasses = ['ocx-card']
       expect(await ocxContentHarness.getContentClasses()).toEqual(expectedClasses)
       expect(await ocxContentHarness.hasTitle(titleBaseId)).toEqual(false)
     })
 
     it('should render a ocxContent card with a title, when given a title via input', async () => {
-      const expectedClasses = ['ocxCard']
+      const expectedClasses = ['ocx-card']
       expect(await ocxContentHarness.getContentClasses()).toEqual(expectedClasses)
       expect(await ocxContentHarness.hasTitle(titleBaseId)).toEqual(false)
 
@@ -64,7 +64,7 @@ describe('OcxContentComponent', () => {
     })
     it('should apply classes specified via input', async () => {
       component.styleClass = 'py-4 mt-2'
-      const expectedStyleClasses = ['ocxCard', 'py-4', 'mt-2']
+      const expectedStyleClasses = ['ocx-card', 'py-4', 'mt-2']
       expect(await ocxContentHarness.getContentClasses()).toEqual(expectedStyleClasses)
     })
   })

--- a/libs/angular-accelerator/src/lib/components/content/content.component.spec.ts
+++ b/libs/angular-accelerator/src/lib/components/content/content.component.spec.ts
@@ -64,7 +64,7 @@ describe('OcxContentComponent', () => {
     })
     it('should apply classes specified via input', async () => {
       component.styleClass = 'py-4 mt-2'
-      const expectedStyleClasses = ['card', 'py-4', 'mt-2']
+      const expectedStyleClasses = ['ocxCard', 'py-4', 'mt-2']
       expect(await ocxContentHarness.getContentClasses()).toEqual(expectedStyleClasses)
     })
   })

--- a/libs/angular-accelerator/src/lib/directives/content.directive.scss
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.scss
@@ -1,33 +1,15 @@
-.card {
+.ocx-card {
 	background-color: var(--content-bg-color, #ffffff);
 	padding: 1rem;
 	margin-bottom: 2rem;
 	box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
 	border-radius: var(--border-radius, 6px);
 
-	&:last-child {
+	p:first-child {
+		margin-top: 0;
+	}
+
+	p:last-child {
 		margin-bottom: 0;
-	}
-
-	.card-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		margin-bottom: 1rem;
-
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			margin: 0;
-		}
-	}
-
-	.card-subtitle {
-		color: var(--text-secondary-color, rgba(0, 0, 0, 0.6));
-		font-weight: 600;
-		margin: -1rem 0 1rem 0;
-	}
+	} 
 }

--- a/libs/angular-accelerator/src/lib/directives/content.directive.scss
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.scss
@@ -1,0 +1,33 @@
+.card {
+	background-color: var(--content-bg-color, #ffffff);
+	padding: 1rem;
+	margin-bottom: 2rem;
+	box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+	border-radius: var(--border-radius, 6px);
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	.card-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1rem;
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			margin: 0;
+		}
+	}
+
+	.card-subtitle {
+		color: var(--text-secondary-color, rgba(0, 0, 0, 0.6));
+		font-weight: 600;
+		margin: -1rem 0 1rem 0;
+	}
+}

--- a/libs/angular-accelerator/src/lib/directives/content.directive.scss
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.scss
@@ -1,4 +1,4 @@
-.ocxCard {
+.ocx-card {
 	background-color: var(--content-bg-color, #ffffff);
 	padding: 1rem;
 	margin-bottom: 2rem;

--- a/libs/angular-accelerator/src/lib/directives/content.directive.scss
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.scss
@@ -1,4 +1,4 @@
-.ocx-card {
+.ocxCard {
 	background-color: var(--content-bg-color, #ffffff);
 	padding: 1rem;
 	margin-bottom: 2rem;

--- a/libs/angular-accelerator/src/lib/directives/content.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.ts
@@ -33,7 +33,7 @@ export class OcxContentDirective implements OnInit, OnChanges {
 
   private addContentStyles() {
     const addClasses = (classes: string[]) => this.el.nativeElement.classList.add(...classes)
-    addClasses(['ocxCard'])
+    addClasses(['ocx-card'])
   }
 
   private prependTitle() {

--- a/libs/angular-accelerator/src/lib/directives/content.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.ts
@@ -33,7 +33,7 @@ export class OcxContentDirective implements OnInit, OnChanges {
 
   private addContentStyles() {
     const addClasses = (classes: string[]) => this.el.nativeElement.classList.add(...classes)
-    addClasses(['card'])
+    addClasses(['ocx-card'])
   }
 
   private prependTitle() {

--- a/libs/angular-accelerator/src/lib/directives/content.directive.ts
+++ b/libs/angular-accelerator/src/lib/directives/content.directive.ts
@@ -33,7 +33,7 @@ export class OcxContentDirective implements OnInit, OnChanges {
 
   private addContentStyles() {
     const addClasses = (classes: string[]) => this.el.nativeElement.classList.add(...classes)
-    addClasses(['ocx-card'])
+    addClasses(['ocxCard'])
   }
 
   private prependTitle() {


### PR DESCRIPTION
.card was a custom style class provided by @portal-layout-styles. Added styling to v7 to match the content component look from v5