### PR TITLE
fix(react): improve permission provider performance and i18n initiali…

### DIFF
--- a/libs/react-integration-interface/src/lib/utils/use-topic.utils.test.ts
+++ b/libs/react-integration-interface/src/lib/utils/use-topic.utils.test.ts
@@ -1,0 +1,113 @@
+import { createElement, StrictMode, type FC, type PropsWithChildren } from 'react'
+import { renderHook } from '@testing-library/react'
+import { useTopic } from './use-topic.utils'
+
+interface MockTopic {
+  destroy: jest.Mock
+  id: number
+}
+
+let topicCounter = 0
+
+class MockTopicClass {
+  id: number
+  destroy: jest.Mock
+
+  constructor() {
+    this.id = ++topicCounter
+    this.destroy = jest.fn()
+  }
+}
+
+const Wrapper: FC<PropsWithChildren<{}>> = ({ children }) => createElement('div', null, children)
+
+const StrictModeWrapper: FC<PropsWithChildren<{}>> = ({ children }) => createElement(StrictMode, null, children)
+
+describe('useTopic', () => {
+  beforeEach(() => {
+    topicCounter = 0
+  })
+
+  it('should create a topic when no external value is provided', () => {
+    const { result } = renderHook(() => useTopic<MockTopic>(undefined, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    expect(result.current).toBeInstanceOf(MockTopicClass)
+  })
+
+  it('should use the external topic when provided', () => {
+    const externalTopic = new MockTopicClass() as any
+    const { result } = renderHook(() => useTopic<MockTopic>(externalTopic, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    expect(result.current).toBe(externalTopic)
+  })
+
+  it('should return the same topic instance across re-renders', () => {
+    const { result, rerender } = renderHook(() => useTopic<MockTopic>(undefined, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it('should not destroy external topic on unmount', () => {
+    const externalTopic = new MockTopicClass() as any
+    const { unmount } = renderHook(() => useTopic<MockTopic>(externalTopic, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    unmount()
+    expect(externalTopic.destroy).not.toHaveBeenCalled()
+  })
+
+  it('should destroy internal topic on real unmount (after setTimeout)', async () => {
+    const { result, unmount } = renderHook(() => useTopic<MockTopic>(undefined, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    const topic = result.current
+    unmount()
+
+    expect(topic.destroy).not.toHaveBeenCalled()
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(topic.destroy).toHaveBeenCalled()
+  })
+
+  it('should not destroy topic on StrictMode remount (setTimeout cancelled by re-mount)', async () => {
+    const { result, unmount } = renderHook(() => useTopic<MockTopic>(undefined, MockTopicClass as any), {
+      wrapper: StrictModeWrapper,
+    })
+    const topic = result.current
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(topic.destroy).not.toHaveBeenCalled()
+
+    unmount()
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(topic.destroy).toHaveBeenCalled()
+  })
+
+  it('should create a new topic when a fresh component is mounted after previous unmount', async () => {
+    const first = renderHook(() => useTopic<MockTopic>(undefined, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    const firstTopic = first.result.current
+    first.unmount()
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const second = renderHook(() => useTopic<MockTopic>(undefined, MockTopicClass as any), {
+      wrapper: Wrapper,
+    })
+    const secondTopic = second.result.current
+
+    expect(secondTopic).not.toBe(firstTopic)
+    expect(secondTopic).toBeInstanceOf(MockTopicClass)
+    second.unmount()
+  })
+})

--- a/libs/react-integration-interface/src/lib/utils/use-topic.utils.ts
+++ b/libs/react-integration-interface/src/lib/utils/use-topic.utils.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 interface Destroyable {
   destroy(): void
@@ -8,24 +8,33 @@ interface Destroyable {
  * Lazily creates a topic instance only when no external value is provided.
  * Destroys internal instances on unmount.
  *
+ * Uses `useState` (lazy init) + `setTimeout(0)` to survive React StrictMode double-mounting:
+ * on cleanup, destruction is deferred to the next tick. If the component re-mounts
+ * before the timeout fires (StrictMode), `isMountedRef` cancels the destruction.
+ *
  * @param valueTopic - optional external topic instance.
  * @param TopicClass - topic class constructor.
  * @returns the resolved topic instance.
  */
-export function useTopic<T extends Destroyable>(
-  valueTopic: T | undefined,
-  TopicClass: new () => T
-): T {
+export function useTopic<T extends Destroyable>(valueTopic: T | undefined, TopicClass: new () => T): T {
   const isExternal = valueTopic !== undefined
-  const topic = useMemo(() => valueTopic ?? new TopicClass(), [valueTopic])
+  const [topic] = useState(() => valueTopic ?? new TopicClass())
+  const isMountedRef = useRef(true)
 
   useEffect(() => {
+    isMountedRef.current = true
+
     return () => {
+      isMountedRef.current = false
       if (!isExternal) {
-        topic.destroy()
+        setTimeout(() => {
+          if (!isMountedRef.current) {
+            topic.destroy()
+          }
+        }, 0)
       }
     }
-  }, [topic, isExternal])
+  }, [isExternal, topic])
 
   return topic
 }

--- a/libs/react-remote-components/src/lib/contexts/permissionContext.test.tsx
+++ b/libs/react-remote-components/src/lib/contexts/permissionContext.test.tsx
@@ -12,6 +12,7 @@ jest.mock('@onecx/integration-interface', () => {
     publish: jest.fn(({ appId, productName }: any) => {
       subject.next({ appId, productName, permissions: [`${appId}-perm`] })
     }),
+    destroy: jest.fn(),
   }
 
   return {
@@ -21,12 +22,12 @@ jest.mock('@onecx/integration-interface', () => {
   }
 })
 
+jest.mock('@onecx/react-integration-interface', () => ({
+  useTopic: (_valueTopic: unknown, TopicClass: new () => unknown) => new TopicClass(),
+}))
+
 function getMockTopic() {
   return (jest.requireMock('@onecx/integration-interface') as any).__mockTopic
-}
-
-function getSubject() {
-  return (jest.requireMock('@onecx/integration-interface') as any).__subject
 }
 
 function renderAndCaptureContext() {
@@ -77,34 +78,11 @@ describe('PermissionProvider', () => {
     expect(getByTestId('child')).toBeDefined()
   })
 
-  it('should provide context with permissions array and getPermissions function', () => {
+  it('should provide context with getPermissions function', () => {
     const { getContext } = renderAndCaptureContext()
     const ctx = getContext()
     expect(ctx).toBeDefined()
-    expect(Array.isArray(ctx.permissions)).toBe(true)
     expect(typeof ctx.getPermissions).toBe('function')
-  })
-
-  it('should subscribe to permissionsTopic on mount', () => {
-    const topic = getMockTopic()
-    renderAndCaptureContext()
-    expect(topic.subscribe).toHaveBeenCalled()
-  })
-
-  it('should unsubscribe from permissionsTopic on unmount', () => {
-    const topic = getMockTopic()
-    const mockUnsubscribe = jest.fn()
-    topic.subscribe.mockReturnValueOnce({ unsubscribe: mockUnsubscribe })
-
-    const { unmount } = render(
-      <PermissionProvider>
-        <div />
-      </PermissionProvider>
-    )
-    act(() => {
-      unmount()
-    })
-    expect(mockUnsubscribe).toHaveBeenCalled()
   })
 
   it('should call publish when getPermissions is called', async () => {
@@ -131,15 +109,35 @@ describe('PermissionProvider', () => {
     expect(result).toEqual(['app-x-perm'])
   })
 
-  it('should update permissions state when topic emits a message', async () => {
-    const subject = getSubject()
+  it('should cache getPermissions results for same appId:productName', async () => {
+    const topic = getMockTopic()
     const { getContext } = renderAndCaptureContext()
+    const ctx = getContext()
 
     await act(async () => {
-      subject.next({ appId: 'a', productName: 'b', permissions: ['read'] })
+      await ctx.getPermissions('cached-app', 'cached-prod')
+    })
+    const initialPublishCount = topic.publish.mock.calls.length
+
+    await act(async () => {
+      await ctx.getPermissions('cached-app', 'cached-prod')
     })
 
+    expect(topic.publish.mock.calls.length).toBe(initialPublishCount)
+  })
+
+  it('should not cache different appId:productName combinations', async () => {
+    const topic = getMockTopic()
+    const { getContext } = renderAndCaptureContext()
     const ctx = getContext()
-    expect(ctx.permissions.length).toBeGreaterThan(0)
+
+    await act(async () => {
+      await ctx.getPermissions('app-a', 'prod-a')
+    })
+    await act(async () => {
+      await ctx.getPermissions('app-b', 'prod-b')
+    })
+
+    expect(topic.publish).toHaveBeenCalledTimes(2)
   })
 })

--- a/libs/react-remote-components/src/lib/contexts/permissionContext.tsx
+++ b/libs/react-remote-components/src/lib/contexts/permissionContext.tsx
@@ -1,37 +1,37 @@
-import { type FC, createContext, useState, useEffect, useMemo, type PropsWithChildren } from 'react'
+import { type FC, createContext, useMemo, type PropsWithChildren } from 'react'
 import { filter, firstValueFrom, map } from 'rxjs'
-import { type PermissionsRpc, PermissionsRpcTopic } from '@onecx/integration-interface'
+import { PermissionsRpcTopic } from '@onecx/integration-interface'
+import { useTopic } from '@onecx/react-integration-interface'
 
 /**
  * Permission context value shape.
  */
 interface PermissionContextType {
-  permissions: PermissionsRpc[]
   getPermissions: (appId: string, productName: string) => Promise<string[]>
 }
 
 /** Permission context for remote components. */
 export const PermissionContext = createContext<PermissionContextType | undefined>(undefined)
 
-const permissionsTopic$ = new PermissionsRpcTopic()
-
 /**
  * Provides permissions fetched from the portal permissions topic.
+ * Mirrors the Angular `PermissionService` pattern: caches results by `appId:productName`
+ * and does not accumulate messages in state, preventing re-render loops.
+ *
  * @param children - nested content rendered with permission context.
  * @returns Permission context provider component.
  */
 export const PermissionProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
-  const [permissions, setPermissions] = useState<PermissionsRpc[]>([])
+  const permissionCache = useMemo(() => new Map<string, Promise<string[]>>(), [])
+  const topic$ = useTopic(undefined, PermissionsRpcTopic)
 
-  /**
-   * Fetch permissions for a given app/product pair.
-   * @param appId - application identifier.
-   * @param productName - product identifier.
-   * @returns list of permissions.
-   */
   const getPermissions = async (appId: string, productName: string): Promise<string[]> => {
+    const cacheKey = `${appId}:${productName}`
+    const cached = permissionCache.get(cacheKey)
+    if (cached) return cached
+
     const permissions = firstValueFrom(
-      permissionsTopic$.pipe(
+      topic$.pipe(
         filter(
           (message) =>
             message.appId === appId && message.productName === productName && Array.isArray(message.permissions)
@@ -39,21 +39,12 @@ export const PermissionProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
         map((message) => message.permissions ?? [])
       )
     )
-    permissionsTopic$.publish({ appId: appId, productName: productName })
+    permissionCache.set(cacheKey, permissions)
+    topic$.publish({ appId, productName })
     return permissions
   }
 
-  useEffect(() => {
-    const subscription = permissionsTopic$.subscribe((message) => {
-      setPermissions((prev) => [...prev, message])
-    })
-
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [])
-
-  const contextValue = useMemo(() => ({ permissions, getPermissions }), [permissions])
+  const contextValue = useMemo(() => ({ getPermissions }), [permissionCache, topic$])
 
   return <PermissionContext.Provider value={contextValue}>{children}</PermissionContext.Provider>
 }

--- a/libs/react-remote-components/src/lib/hooks/usePermission.test.tsx
+++ b/libs/react-remote-components/src/lib/hooks/usePermission.test.tsx
@@ -4,7 +4,6 @@ import { PermissionContext } from '../contexts/permissionContext'
 import { usePermission } from './usePermission'
 
 const mockPermissionService = {
-  permissions: [],
   getPermissions: jest.fn(() => Promise.resolve(['perm1', 'perm2'])),
 }
 
@@ -24,11 +23,6 @@ describe('usePermission', () => {
   it('should return the permission context value', () => {
     const { result } = renderHook(() => usePermission(), { wrapper: PermissionProviderWrapper })
     expect(result.current).toBe(mockPermissionService)
-  })
-
-  it('should expose permissions array', () => {
-    const { result } = renderHook(() => usePermission(), { wrapper: PermissionProviderWrapper })
-    expect(Array.isArray(result.current.permissions)).toBe(true)
   })
 
   it('should expose getPermissions function', () => {

--- a/libs/react-remote-components/src/lib/hooks/usePermission.test.tsx
+++ b/libs/react-remote-components/src/lib/hooks/usePermission.test.tsx
@@ -3,6 +3,10 @@ import { type FC, type PropsWithChildren } from 'react'
 import { PermissionContext } from '../contexts/permissionContext'
 import { usePermission } from './usePermission'
 
+jest.mock('@onecx/react-integration-interface', () => ({
+  useTopic: (_valueTopic: unknown, TopicClass: new () => unknown) => new TopicClass(),
+}))
+
 const mockPermissionService = {
   getPermissions: jest.fn(() => Promise.resolve(['perm1', 'perm2'])),
 }

--- a/libs/react-remote-components/src/lib/hooks/useSlot.test.tsx
+++ b/libs/react-remote-components/src/lib/hooks/useSlot.test.tsx
@@ -3,6 +3,10 @@ import { type FC, type PropsWithChildren } from 'react'
 import { SlotContext } from '../contexts/slotContext'
 import { useSlot } from './useSlot'
 
+jest.mock('@onecx/react-integration-interface', () => ({
+  useTopic: (_valueTopic: unknown, TopicClass: new () => unknown) => new TopicClass(),
+}))
+
 const mockSlotService = {
   remoteComponents$: {} as any,
   getComponentsForSlot: jest.fn(),

--- a/libs/react-remote-components/src/lib/wrapper/withSlot.test.tsx
+++ b/libs/react-remote-components/src/lib/wrapper/withSlot.test.tsx
@@ -17,6 +17,10 @@ jest.mock('@onecx/integration-interface', () => {
   }
 })
 
+jest.mock('@onecx/react-integration-interface', () => ({
+  useTopic: (_valueTopic: unknown, TopicClass: new () => unknown) => new TopicClass(),
+}))
+
 jest.mock('../utils/getShellMfInstance', () => ({
   getShellMfInstance: jest.fn(() => ({
     name: 'onecx-shell-ui',

--- a/libs/react-utils/src/lib/utils/translationBridge.test.tsx
+++ b/libs/react-utils/src/lib/utils/translationBridge.test.tsx
@@ -1,11 +1,21 @@
-import { createElement } from 'react'
 import { render } from '@testing-library/react'
-import { TranslationBridge } from './translationBridge'
+import { TranslationBridge, __resetI18nInitialized } from './translationBridge'
+
+const mockChangeLanguage = jest.fn()
+const mockInit = jest.fn()
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn(() => ({
-    i18n: { changeLanguage: jest.fn() },
+    i18n: { changeLanguage: mockChangeLanguage, isInitialized: true, init: mockInit },
   })),
+}))
+
+jest.mock('i18next', () => ({
+  __esModule: true,
+  default: {
+    isInitialized: true,
+    init: mockInit,
+  },
 }))
 
 jest.mock('@onecx/react-integration-interface', () => ({
@@ -17,48 +27,109 @@ jest.mock('@onecx/react-integration-interface', () => ({
 }))
 
 describe('TranslationBridge', () => {
+  const { useTranslation } = require('react-i18next') as { useTranslation: jest.Mock }
+  const { useUserService } = require('@onecx/react-integration-interface') as { useUserService: jest.Mock }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    __resetI18nInitialized()
+    useTranslation.mockReturnValue({
+      i18n: { changeLanguage: mockChangeLanguage, isInitialized: true, init: mockInit },
+    })
+    useUserService.mockReturnValue({
+      lang$: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) },
+    })
+  })
+
   it('should render null', () => {
-    const { container } = render(createElement(TranslationBridge))
+    const { container } = render(<TranslationBridge />)
     expect(container.innerHTML).toBe('')
   })
 
   it('should subscribe to lang$ on mount', () => {
-    const { useUserService } = require('@onecx/react-integration-interface')
     const mockSubscribe = jest.fn(() => ({ unsubscribe: jest.fn() }))
     useUserService.mockReturnValue({ lang$: { subscribe: mockSubscribe } })
 
-    render(createElement(TranslationBridge))
+    render(<TranslationBridge />)
     expect(mockSubscribe).toHaveBeenCalled()
   })
 
   it('should unsubscribe from lang$ on unmount', () => {
-    const { useUserService } = require('@onecx/react-integration-interface')
     const mockUnsubscribe = jest.fn()
-    useUserService.mockReturnValue({ lang$: { subscribe: jest.fn(() => ({ unsubscribe: mockUnsubscribe })) } })
+    useUserService.mockReturnValue({
+      lang$: { subscribe: jest.fn(() => ({ unsubscribe: mockUnsubscribe })) },
+    })
 
-    const { unmount } = render(createElement(TranslationBridge))
+    const { unmount } = render(<TranslationBridge />)
     unmount()
     expect(mockUnsubscribe).toHaveBeenCalled()
   })
 
   it('should call i18n.changeLanguage when lang emits', () => {
-    const { useUserService } = require('@onecx/react-integration-interface')
-    const { useTranslation } = require('react-i18next')
-    const mockChangeLanguage = jest.fn()
-    let capturedCallback: any
+    let capturedCallback!: (lang: string) => void
 
-    useTranslation.mockReturnValue({ i18n: { changeLanguage: mockChangeLanguage } })
     useUserService.mockReturnValue({
       lang$: {
-        subscribe: jest.fn((cb: any) => {
+        subscribe: jest.fn((cb: (lang: string) => void) => {
           capturedCallback = cb
           return { unsubscribe: jest.fn() }
         }),
       },
     })
 
-    render(createElement(TranslationBridge))
+    render(<TranslationBridge />)
     capturedCallback('de')
     expect(mockChangeLanguage).toHaveBeenCalledWith('de')
+  })
+
+  it('should initialize i18n when not already initialized', () => {
+    useTranslation.mockReturnValue({
+      i18n: { changeLanguage: mockChangeLanguage, isInitialized: false, init: mockInit },
+    })
+
+    render(<TranslationBridge />)
+
+    expect(mockInit).toHaveBeenCalledWith({
+      fallbackLng: 'en',
+      resources: {},
+      interpolation: { escapeValue: false },
+    })
+  })
+
+  it('should not initialize i18n when i18n.isInitialized is true', () => {
+    useTranslation.mockReturnValue({
+      i18n: { changeLanguage: mockChangeLanguage, isInitialized: true, init: mockInit },
+    })
+
+    render(<TranslationBridge />)
+
+    expect(mockInit).not.toHaveBeenCalled()
+  })
+
+  it('should not initialize i18n when module flag is already set from prior render', () => {
+    useTranslation.mockReturnValue({
+      i18n: { changeLanguage: mockChangeLanguage, isInitialized: false, init: mockInit },
+    })
+
+    render(<TranslationBridge />)
+    expect(mockInit).toHaveBeenCalledTimes(1)
+
+    render(<TranslationBridge />)
+    expect(mockInit).toHaveBeenCalledTimes(1)
+  })
+
+  it('should re-subscribe when lang$ reference changes', () => {
+    const mockSubscribe1 = jest.fn(() => ({ unsubscribe: jest.fn() }))
+    const mockSubscribe2 = jest.fn(() => ({ unsubscribe: jest.fn() }))
+
+    useUserService.mockReturnValue({ lang$: { subscribe: mockSubscribe1 } })
+
+    const { rerender } = render(<TranslationBridge />)
+    expect(mockSubscribe1).toHaveBeenCalledTimes(1)
+
+    useUserService.mockReturnValue({ lang$: { subscribe: mockSubscribe2 } })
+    rerender(<TranslationBridge />)
+
+    expect(mockSubscribe2).toHaveBeenCalledTimes(1)
   })
 })

--- a/libs/react-utils/src/lib/utils/translationBridge.test.tsx
+++ b/libs/react-utils/src/lib/utils/translationBridge.test.tsx
@@ -1,21 +1,12 @@
 import { render } from '@testing-library/react'
-import { TranslationBridge, __resetI18nInitialized } from './translationBridge'
+import { TranslationBridge } from './translationBridge'
 
 const mockChangeLanguage = jest.fn()
-const mockInit = jest.fn()
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn(() => ({
-    i18n: { changeLanguage: mockChangeLanguage, isInitialized: true, init: mockInit },
+    i18n: { changeLanguage: mockChangeLanguage, isInitialized: true },
   })),
-}))
-
-jest.mock('i18next', () => ({
-  __esModule: true,
-  default: {
-    isInitialized: true,
-    init: mockInit,
-  },
 }))
 
 jest.mock('@onecx/react-integration-interface', () => ({
@@ -32,9 +23,8 @@ describe('TranslationBridge', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    __resetI18nInitialized()
     useTranslation.mockReturnValue({
-      i18n: { changeLanguage: mockChangeLanguage, isInitialized: true, init: mockInit },
+      i18n: { changeLanguage: mockChangeLanguage, isInitialized: true },
     })
     useUserService.mockReturnValue({
       lang$: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) },
@@ -82,40 +72,24 @@ describe('TranslationBridge', () => {
     expect(mockChangeLanguage).toHaveBeenCalledWith('de')
   })
 
-  it('should initialize i18n when not already initialized', () => {
+  it('should skip changeLanguage when i18n is not initialized', () => {
+    let capturedCallback!: (lang: string) => void
+
     useTranslation.mockReturnValue({
-      i18n: { changeLanguage: mockChangeLanguage, isInitialized: false, init: mockInit },
+      i18n: { changeLanguage: mockChangeLanguage, isInitialized: false },
+    })
+    useUserService.mockReturnValue({
+      lang$: {
+        subscribe: jest.fn((cb: (lang: string) => void) => {
+          capturedCallback = cb
+          return { unsubscribe: jest.fn() }
+        }),
+      },
     })
 
     render(<TranslationBridge />)
-
-    expect(mockInit).toHaveBeenCalledWith({
-      fallbackLng: 'en',
-      resources: {},
-      interpolation: { escapeValue: false },
-    })
-  })
-
-  it('should not initialize i18n when i18n.isInitialized is true', () => {
-    useTranslation.mockReturnValue({
-      i18n: { changeLanguage: mockChangeLanguage, isInitialized: true, init: mockInit },
-    })
-
-    render(<TranslationBridge />)
-
-    expect(mockInit).not.toHaveBeenCalled()
-  })
-
-  it('should not initialize i18n when module flag is already set from prior render', () => {
-    useTranslation.mockReturnValue({
-      i18n: { changeLanguage: mockChangeLanguage, isInitialized: false, init: mockInit },
-    })
-
-    render(<TranslationBridge />)
-    expect(mockInit).toHaveBeenCalledTimes(1)
-
-    render(<TranslationBridge />)
-    expect(mockInit).toHaveBeenCalledTimes(1)
+    capturedCallback('de')
+    expect(mockChangeLanguage).not.toHaveBeenCalled()
   })
 
   it('should re-subscribe when lang$ reference changes', () => {

--- a/libs/react-utils/src/lib/utils/translationBridge.tsx
+++ b/libs/react-utils/src/lib/utils/translationBridge.tsx
@@ -1,6 +1,22 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import i18next from 'i18next'
 import { useUserService } from '@onecx/react-integration-interface'
+
+let i18nInitialized = false
+
+const ensureI18nInitialized = (i18n: typeof i18next) => {
+  if (i18nInitialized || i18n.isInitialized) {
+    i18nInitialized = true
+    return
+  }
+  i18nInitialized = true
+  void i18n.init({
+    fallbackLng: 'en',
+    resources: {},
+    interpolation: { escapeValue: false },
+  })
+}
 
 /**
  * Syncs the user language stream with i18next.
@@ -11,6 +27,8 @@ export const TranslationBridge = () => {
   const { i18n } = useTranslation()
   const { lang$ } = useUserService()
 
+  ensureI18nInitialized(i18n)
+
   useEffect(() => {
     const subscription = lang$.subscribe((lang) => {
       void i18n.changeLanguage(lang)
@@ -20,4 +38,8 @@ export const TranslationBridge = () => {
   }, [i18n, lang$])
 
   return null
+}
+
+export const __resetI18nInitialized = () => {
+  i18nInitialized = false
 }

--- a/libs/react-utils/src/lib/utils/translationBridge.tsx
+++ b/libs/react-utils/src/lib/utils/translationBridge.tsx
@@ -11,7 +11,7 @@ const ensureI18nInitialized = (i18n: typeof i18next) => {
     return
   }
   i18nInitialized = true
-  void i18n.init({
+  i18n.init({
     fallbackLng: 'en',
     resources: {},
     interpolation: { escapeValue: false },

--- a/libs/react-utils/src/lib/utils/translationBridge.tsx
+++ b/libs/react-utils/src/lib/utils/translationBridge.tsx
@@ -1,25 +1,12 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import i18next from 'i18next'
 import { useUserService } from '@onecx/react-integration-interface'
-
-let i18nInitialized = false
-
-const ensureI18nInitialized = (i18n: typeof i18next) => {
-  if (i18nInitialized || i18n.isInitialized) {
-    i18nInitialized = true
-    return
-  }
-  i18nInitialized = true
-  i18n.init({
-    fallbackLng: 'en',
-    resources: {},
-    interpolation: { escapeValue: false },
-  })
-}
 
 /**
  * Syncs the user language stream with i18next.
+ *
+ * Skips language changes until i18n is initialized — react-i18next
+ * handles initialization via its own provider/boundaries.
  *
  * @returns Null (side-effects only).
  */
@@ -27,19 +14,15 @@ export const TranslationBridge = () => {
   const { i18n } = useTranslation()
   const { lang$ } = useUserService()
 
-  ensureI18nInitialized(i18n)
-
   useEffect(() => {
     const subscription = lang$.subscribe((lang) => {
-      void i18n.changeLanguage(lang)
+      if (i18n.isInitialized) {
+        i18n.changeLanguage(lang)
+      }
     })
 
     return () => subscription.unsubscribe()
   }, [i18n, lang$])
 
   return null
-}
-
-export const __resetI18nInitialized = () => {
-  i18nInitialized = false
 }


### PR DESCRIPTION
…zation

- Add i18n initialization guard in TranslationBridge to prevent errors when i18next is not initialized
- Refactor useTopic to use useState instead of useRef for React 19 compliance
- Add StrictMode resilience to useTopic with setTimeout(0) + isMountedRef
- Align PermissionProvider with Angular PermissionService: add caching, remove state accumulation
- Switch PermissionProvider to use useTopic for automatic topic lifecycle management
- Update all related tests